### PR TITLE
Added paddingLeft and paddingRight

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,68 @@ Array to delimited string data transformer
 
 This is a data transformer for the Symfony form framework.
 
-It will transform a string input, such as `foo, bar, bar, foo` to an array
-e.g. `array('foo', 'bar', bar', foo')`.
+It is meant for transforming text fields containing delimited strings to
+arrays.
 
 Usage
 -----
 
+You can use the data transformer as follows:
+
 ````php
-$form->add($builder->create('tags', 'text')->addModelTransformer(new ArrayToDelimitedStringTransformer()))
+$form->add(
+    $builder->create('tags', 'text')->addModelTransformer(
+        new ArrayToDelimitedStringTransformer()
+    )
+);
 ````
 
+This will transform the ``tags`` text field as follows:
+
+````php
+// Tranform
+array('one', 'two', 'three', 'four') === 'one, two, three, four'
+
+// Reverse transform
+'   one ,  two    , three, four,' === array('one', two', 'three', 'four')
+````
+
+Changing the delimiter
+----------------------
+
+You can change the delimiting string with the first constructor argument:
+
+````php
+new ArrayToDelimitedStringTransformer(';')
+````
+
+Will result in:
+
+````php
+// Transform
+array('one', 'two', 'three', 'four') === 'one; two; three; four'
+
+// Reverse Transform
+'one   ; two;three ;     four' => array('one', 'two', 'three')
+````
+
+Output padding
+--------------
+
+Additionally you can change the way in which the output is formatted with
+by setting the amount of whitespace (padding) before and after the text
+elements produced by a transformation:
+
+````php
+new ArrayToDelimitedStringTransformer('%', 1, 1)
+````
+
+Will result in:
+
+````php
+// Transform
+array('one', 'two', 'three', 'four') === 'one % two % three % four'
+
+// Reverse Transform
+'one   % two%three %     four' => array('one', 'two', 'three')
+````

--- a/lib/ArrayToDelimitedStringTransformer.php
+++ b/lib/ArrayToDelimitedStringTransformer.php
@@ -23,20 +23,22 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 class ArrayToDelimitedStringTransformer implements DataTransformerInterface
 {
     private $delimiter;
-    private $format;
+    private $paddingLeft;
+    private $paddingRight;
 
     /**
      * Constructor
      *
      * @param string $delimiter The delimiter to use when transforming from
      * a string to an array and vice-versa
-     * @param string $format The format to use when reconstructing the
-     * string
+     * @param integer Number of spaces before each transformed array element
+     * @param integer Number of spaces after each transformed array element
      */
-    public function __construct($delimiter = ',', $format = ' %s')
+    public function __construct($delimiter = ',', $paddingLeft = 0, $paddingRight = 1)
     {
         $this->delimiter = $delimiter;
-        $this->format = $format;
+        $this->paddingLeft = $paddingLeft;
+        $this->paddingRight = $paddingRight;
     }
 
     /**
@@ -59,7 +61,11 @@ class ArrayToDelimitedStringTransformer implements DataTransformerInterface
         }
 
         foreach ($array as &$value) {
-            $value = sprintf($this->format, $value);
+            $value = sprintf('%s%s%s',
+                str_repeat(' ', $this->paddingLeft),
+                $value,
+                str_repeat(' ', $this->paddingRight)
+            );
         }
 
         $string = trim(implode($this->delimiter, $array));

--- a/tests/ArrayToDelimitedStringTransformerTest.php
+++ b/tests/ArrayToDelimitedStringTransformerTest.php
@@ -11,6 +11,8 @@
 
 namespace DTL\Symfony\Form\DataTransformer;
 
+use DTL\Symfony\Form\DataTransformer\ArrayToDelimitedStringTransformer;
+
 class ArrayToDelimitedStringTransformerTest extends \PHPUnit_Framework_TestCase
 {
     public function provideReverseTransform()
@@ -72,25 +74,24 @@ class ArrayToDelimitedStringTransformerTest extends \PHPUnit_Framework_TestCase
                 array('foo', 'bar', 'foo'),
                 'foo ,bar ,foo',
                 ',',
-                '%s ',
+                0 , 1
             ),
             array(
                 array('foo', 'bar', 'foo'),
                 'foo,bar,foo',
                 ',',
-                '%s',
+                0, 0
             ),
             array(
                 array('foo', 'bar', 'foo'),
                 'foo , bar , foo',
                 ',',
-                ' %s ',
+                1, 1
             ),
             array(
                 array('foo'),
                 'foo',
                 ',',
-                '%s',
             ),
             array(
                 null,
@@ -98,6 +99,7 @@ class ArrayToDelimitedStringTransformerTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 'asdasd',
+                null,
                 null,
                 null,
                 null,
@@ -109,13 +111,13 @@ class ArrayToDelimitedStringTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideTransform
      */
-    public function testTransform($array, $string, $delimiter = null, $format = null, $expectedException = null)
+    public function testTransform($array, $string, $delimiter = null, $paddingLeft = null, $paddingRight = null, $expectedException = null)
     {
         if ($expectedException) {
             $this->setExpectedException('Symfony\Component\Form\Exception\TransformationFailedException', $expectedException);
         }
 
-        $transformer = new ArrayToDelimitedStringTransformer($delimiter, $format);
+        $transformer = new ArrayToDelimitedStringTransformer($delimiter, $paddingLeft, $paddingRight);
         $res = $transformer->transform($array);
         $this->assertEquals($string, $res);
     }


### PR DESCRIPTION
Have replaced the $format argument with paddingLeft and paddingRight
as the format option could have been misused causing the transformer
to break.

Also updated README
