### PR TITLE
Space as a delimiter tests

### DIFF
--- a/tests/ArrayToDelimitedStringTransformerTest.php
+++ b/tests/ArrayToDelimitedStringTransformerTest.php
@@ -121,5 +121,52 @@ class ArrayToDelimitedStringTransformerTest extends \PHPUnit_Framework_TestCase
         $res = $transformer->transform($array);
         $this->assertEquals($string, $res);
     }
-}
 
+    /**
+     * @dataProvider provideSpaceAsDelimiterExamples
+     */
+    public function testSpaceAsDelimiter(array $array, $string, $message = null)
+    {
+        $transformer = new ArrayToDelimitedStringTransformer(' ', 0, 0);
+
+        $this->assertSame($string, $transformer->transform($array), $message);
+
+        $this->assertSame($array, $transformer->reverseTransform($string), $message);
+    }
+
+    public function provideSpaceAsDelimiterExamples()
+    {
+        return array(
+            array(
+                array('foo', 'bar', 'baz'),
+                'foo bar baz',
+                'Space as a delimiter',
+            ),
+            array(
+                array('foo', 'bar', '',  'baz'),
+                'foo bar  baz',
+                'Empty elements are preserved',
+            ),
+            array(
+                array('', 'foo'),
+                ' foo',
+                'Empty elements at the beginning are preserved',
+            ),
+            array(
+                array('foo', ''),
+                'foo ',
+                'Empty elements at the end are preserved',
+            ),
+            array(
+                array('', '', 'foo'),
+                '  foo',
+                'Empty elements at the beginning are preserved',
+            ),
+            array(
+                array('foo', '', ''),
+                'foo  ',
+                'Empty elements at the end are preserved',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
https://github.com/dantleech/symfony-form-array-to-delimited-string-transformer/issues/5

Tests result:

```
$ vendor/bin/phpunit
PHPUnit 4.3.1 by Sebastian Bergmann.

Configuration read from symfony-form-array-to-delimited-string-transformer/phpunit.xml.dist

...............FFFF

Time: 85 ms, Memory: 3.75Mb

There were 4 failures:

1) DTL\Symfony\Form\DataTransformer\ArrayToDelimitedStringTransformerTest::testSpaceAsDelimiter with data set #2 (array('', 'foo'), ' foo', 'Empty elements at the beginning are preserved')
Empty elements at the beginning are preserved
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
- foo
+foo

symfony-form-array-to-delimited-string-transformer/tests/ArrayToDelimitedStringTransformerTest.php:132

2) DTL\Symfony\Form\DataTransformer\ArrayToDelimitedStringTransformerTest::testSpaceAsDelimiter with data set #3 (array('foo', ''), 'foo ', 'Empty elements at the end are preserved')
Empty elements at the end are preserved
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-foo 
+foo

symfony-form-array-to-delimited-string-transformer/tests/ArrayToDelimitedStringTransformerTest.php:132

3) DTL\Symfony\Form\DataTransformer\ArrayToDelimitedStringTransformerTest::testSpaceAsDelimiter with data set #4 (array('', '', 'foo'), '  foo', 'Empty elements at the beginning are preserved')
Empty elements at the beginning are preserved
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-  foo
+foo

symfony-form-array-to-delimited-string-transformer/tests/ArrayToDelimitedStringTransformerTest.php:132

4) DTL\Symfony\Form\DataTransformer\ArrayToDelimitedStringTransformerTest::testSpaceAsDelimiter with data set #5 (array('foo', '', ''), 'foo  ', 'Empty elements at the end are preserved')
Empty elements at the end are preserved
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-foo  
+foo

symfony-form-array-to-delimited-string-transformer/tests/ArrayToDelimitedStringTransformerTest.php:132

FAILURES!                              
Tests: 19, Assertions: 23, Failures: 4.
```

Do we fix that?
